### PR TITLE
[INFRA-1534] - Custom WAR path should not be a directory

### DIFF
--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -95,6 +95,7 @@ def call(Map params = [:]) {
                 }
             } else {
                 def tag = pctUrl - "docker://"
+                sh "docker pull ${tag}"
                 pctContainerImage = docker.image(tag)
             }
 

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -109,6 +109,7 @@ def call(Map params = [:]) {
                     pctContainerImage.inside(containerArgsBase) {
                         unstash "jenkinsWar"
                         def warAbsolutePath = pwd() + "/jenkins.war"
+                        def command = 'JENKINS_WAR_PATH=${warAbsolutePath} run-pct'
                         if (localSnapshots && localPluginsStashName) {
                             dir("localPlugins") {
                                 unstash name: localPluginsStashName

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -110,9 +110,9 @@ def call(Map params = [:]) {
                     pctContainerImage.inside(containerArgsBase) {
                         unstash "jenkinsWar"
                         def warAbsolutePath = pwd() + "/jenkins.war"
-                        if(metadata.jth) {
+                        if(metadata.jth != null) {
                             def mavenOptions = []
-                            if (metadata.jth.version) {
+                            if (metadata.jth.version != null) {
                                 mavenOptions << "jenkins-test-harness.version=${metadata.jth.version}"
                             }
                             if(metadata.jth.passCustomJenkinsWAR) {

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -11,6 +11,7 @@ def call(Map params = [:]) {
     def jenkins = params.get('jenkins', 'latest')
     def pctExtraOptions = params.get('pctExtraOptions', [])
     def javaOptions = params.get('javaOptions', [])
+    def dockerOptions = params.get('dockerOptions', [])
 
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
     def metadata
@@ -104,7 +105,7 @@ def call(Map params = [:]) {
             def localSnapshots = metadata.useLocalSnapshots != null ? metadata.useLocalSnapshots : true
 
             def testingBranches = [:]
-            def containerArgsBase = "-v /var/run/docker.sock:/var/run/docker.sock -u root"
+            def containerArgsBase = "-v /var/run/docker.sock:/var/run/docker.sock -u root ${dockerOptions.join(' ')}"
             for (def i = 0; i < plugins.size(); i++) {
                 def plugin = plugins[i]
                 testingBranches["PCT-${plugin}"] = {

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -110,6 +110,17 @@ def call(Map params = [:]) {
                     pctContainerImage.inside(containerArgsBase) {
                         unstash "jenkinsWar"
                         def warAbsolutePath = pwd() + "/jenkins.war"
+                        if(metadata.jth) {
+                            def mavenOptions = []
+                            if (metadata.jth.version) {
+                                mavenOptions << "jenkins-test-harness.version=${metadata.jth.version}"
+                            }
+                            if(metadata.jth.passCustomJenkinsWAR) {
+                                mavenOptions << "jth.jenkins-war.path=${warAbsolutePath}"
+                            }
+                            pctExtraOptions << "-mavenProperties"
+                            pctExtraOptions << "${mavenOptions.join(':')}"
+                        }
                         def command = "JENKINS_WAR_PATH=${warAbsolutePath} run-pct ${pctExtraOptions.join(' ')}"
                         if (!javaOptions.isEmpty()) {
                             command = "JAVA_OPTS=${javaOptions.join(' ')} ${command}"

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -110,6 +110,8 @@ def call(Map params = [:]) {
                     pctContainerImage.inside(containerArgsBase) {
                         unstash "jenkinsWar"
                         def warAbsolutePath = pwd() + "/jenkins.war"
+                        def pctBranchOptions = []
+                        pctBranchOptions.addAll(pctExtraOptions)
                         if(metadata.jth != null) {
                             def mavenOptions = []
                             if (metadata.jth.version != null) {
@@ -118,10 +120,10 @@ def call(Map params = [:]) {
                             if(metadata.jth.passCustomJenkinsWAR) {
                                 mavenOptions << "jth.jenkins-war.path=${warAbsolutePath}"
                             }
-                            pctExtraOptions << "-mavenProperties"
-                            pctExtraOptions << "${mavenOptions.join(':')}"
+                            pctBranchOptions << "-mavenProperties"
+                            pctBranchOptions << "${mavenOptions.join(':')}"
                         }
-                        def command = "JENKINS_WAR_PATH=${warAbsolutePath} run-pct ${pctExtraOptions.join(' ')}"
+                        def command = "JENKINS_WAR_PATH=${warAbsolutePath} run-pct ${pctBranchOptions.join(' ')}"
                         if (!javaOptions.isEmpty()) {
                             command = "JAVA_OPTS=${javaOptions.join(' ')} ${command}"
                         }

--- a/vars/runPCT.txt
+++ b/vars/runPCT.txt
@@ -19,6 +19,7 @@ The list of step's params and the related default values are:
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
     <li>pctExtraOptions: List of extra PCT options to be passed to the PCT executable. Defaults to empty list</li>
     <li>javaOptions: List of extra Java options to be passed to the PCT executable. Defaults to empty list</li>
+    <li>dockerOptions: List of extra options to be passed to PCT containers ( e.g. &qt;-v maven-repo:/root/.m2&qt;)</p>
 </ul>
 
 <pre>

--- a/vars/runPCT.txt
+++ b/vars/runPCT.txt
@@ -17,7 +17,8 @@ The list of step's params and the related default values are:
     <li>pctRevision: The PCT revision to use in case that pctUrl points to a github destination, can be a branch or tag name or a commit id. Defaults to branch master. <b>Can be overridden from the metadata file</b></li>
     <li>metadataFile: A String indicating the file path (relative to the where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. <b>Defaults to <i>essentials.yml</i> at the location where this step is invoked</b></li>
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
-    <li>pctExtraOptions: List of extra options to be passed to the PCT executable. Defaults to empty list</li>
+    <li>pctExtraOptions: List of extra PCT options to be passed to the PCT executable. Defaults to empty list</li>
+    <li>javaOptions: List of extra Java options to be passed to the PCT executable. Defaults to empty list</li>
 </ul>
 
 <pre>


### PR DESCRIPTION
Current version passes jenkins.war as a volume, but due to whatever reason it actually appears to be a directory on my Docker version. So I switched passing Jenkins WAR as a volume to a more reliable local unstash + passing WAR to `run-pct` by an env variable